### PR TITLE
Updates project version

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,7 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+[git]
+conventional_commits = false
+filter_unconventional = true
+require_conventional = false

--- a/cliff.toml
+++ b/cliff.toml
@@ -3,5 +3,3 @@
 
 [git]
 conventional_commits = false
-filter_unconventional = true
-require_conventional = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ Issues = "https://github.com/shortstorybox/printserver/issues"
 
 [project]
 name = "printserver"
-version = "2.4.3"  # Updated by `make version-bump`
+version = "2.4.5"  # Updated by `make version-bump`
 description = "The missing JavaScript Printer API"
 license = "GPL-3.0-or-later"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -646,7 +646,7 @@ wheels = [
 
 [[package]]
 name = "printserver"
-version = "2.4.3"
+version = "2.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "brother-ql" },


### PR DESCRIPTION
**Summary**
Attempts to fix version release process to deploy new printserver version

**Additional Context**
`make release` depends on a combination of git tags, `pyproject.toml` version, and the output of `git-cliff`; it looks like this has been partially broken since the previous-previous release (2.4.3?).

It's not clear to me how 2.4.4 was released—since `git cliff` expects conventional commits—but this PR adds in basic config for `git cliff` which _should_ unblock that, _and_ bumps the version number.

...I don't know if this will fully resolve the issue, but it should help (I hope)